### PR TITLE
Added series context menu and integrated describewindow with displayapp

### DIFF
--- a/src/describewindow.py
+++ b/src/describewindow.py
@@ -133,7 +133,7 @@ class DescriptionTable(ttk.Frame):
             cell.destroy()
 
     def populate(self, data, header_text):
-        max_width = max(len(series), 5)
+        max_width = max(len(header_text), 5)
         header = TableCell(self, background='#333333', foreground='#f0f0f0',
                            text=header_text, width=6+max_width)
         header.grid(column=0, row=0, columnspan=2)
@@ -204,18 +204,19 @@ class DescriptionFrame(ttk.LabelFrame):
 
 
 class DescribeWindow(tk.Toplevel):
-    def __init__(self):
+    def __init__(self, series):
         super().__init__()
         self.title('Description')
         self.geometry('900x600+100+100')
+        self.series = series
         self.source_frame = SourceFrame(self)
         self.source_frame.pack()
         self.description_frame = DescriptionFrame(self, series)
         self.description_frame.pack()
 
-    def update(self, data, series, interval, agg_metric):
-        self.source_frame.update(series, interval, agg_metric)
-        self.description_frame.update(data, series)
+    def update(self, data, interval, agg_metric='mean'):
+        self.source_frame.update(self.series, interval, agg_metric)
+        self.description_frame.update(data, self.series)
 
 
 

--- a/src/displayapp.py
+++ b/src/displayapp.py
@@ -196,7 +196,55 @@ class DisplayApp(tk.Tk):
                     master=self.frame.scrollable_frame)
             self.plots.append(data_plot)
             data_plot.draw()
-            data_plot.get_tk_widget().pack(fill=X, expand=True)
+            plot_widget = data_plot.get_tk_widget()
+            plot_widget.pack(fill=X, expand=True)
+
+
+class SeriesContextMenu(tk.Menu):
+    def __init__(self, parent, on_aggregate=None, on_describe=None,
+                 on_query=None, on_save_figure=None, on_draw=None,
+                 on_delete=None, tear_off=0, **kwargs):
+        super().__init__(parent, tearoff=tearoff, **kwargs)
+        intervals = ('1ms', '5ms', '50ms', '500ms', '1S', '1min', '30min', '1H',
+                     '3H', '6H', 'D', 'W')
+        agg_menu = tk.Menu(self)
+        for interval in intervals:
+            agg_menu.add_command(
+                label=interval,
+                command=lambda : on_aggregate(interval)
+            )
+        self.add_cascade(
+            label='Aggregate',
+            menu=agg_menu
+        )
+        self.add_command(
+            label='Describe',
+            command=on_describe
+        )
+        self.add_command(
+            label='Query',
+            command=on_query
+        )
+        self.add_separator()
+        self.add_command(
+            label='Save figure',
+            command=on_save_figure
+        )
+        self.add_command(
+            label='Draw',
+            command=on_draw
+        )
+        self.add_separator()
+        self.add_command(
+            label='Delete',
+            command=on_delete
+        )
+
+    def popup(event):
+        try:
+            self.tk_popup(event.x_root, event.y_root)
+        finally:
+            self.grav_release()
 
 
 

--- a/src/displayapp.py
+++ b/src/displayapp.py
@@ -88,6 +88,7 @@ class DisplayApp(tk.Tk):
         self.plots = [] # used to easily reference displayed plots
         self._active_data = None
         self.describe_window = None
+        self.interval = '1min'
         self.title('Data Analyzer')
         self.geometry('900x600+50+50')
         self.resizable(True, True)
@@ -148,10 +149,13 @@ class DisplayApp(tk.Tk):
     def update_describe_window(self):
         if self.describe_window is None:
             return
-        # TODO
-        #self.describe_window.update_time(time_min, time_max)
-        # or
-        #self.describe_window.update_data(self.active_data)
+        self.describe_window.update(self._active_data, self.interval)
+
+    def open_describe_window(self, series):
+        if self.describe_window:
+            self.describe_window.destroy()
+        self.describe_window = DescribeWindow(series)
+        self.describe_window.update(self._active_data, self.interval)
 
     def open_import_window(self):
         print('DisplayApp.open_import_window()')
@@ -200,7 +204,7 @@ class DisplayApp(tk.Tk):
             context_menu = SeriesContextMenu(
                 self.frame.scrollable_frame,
                 on_aggregate=lambda x: print('on_aggregate({})'.format(x)),
-                on_describe=lambda : print('on_describe()'),
+                on_describe=lambda c=col_name: self.open_describe_window(c),
                 on_query=lambda : print('on_query()'),
                 on_save_figure=lambda : print('on_save_figure()'),
                 on_draw=lambda : print('on_draw()'),

--- a/src/displayapp.py
+++ b/src/displayapp.py
@@ -197,21 +197,34 @@ class DisplayApp(tk.Tk):
             self.plots.append(data_plot)
             data_plot.draw()
             plot_widget = data_plot.get_tk_widget()
+            context_menu = SeriesContextMenu(
+                self.frame.scrollable_frame,
+                on_aggregate=lambda x: print('on_aggregate({})'.format(x)),
+                on_describe=lambda : print('on_describe()'),
+                on_query=lambda : print('on_query()'),
+                on_save_figure=lambda : print('on_save_figure()'),
+                on_draw=lambda : print('on_draw()'),
+                on_delete=lambda : print('on_delete()')
+            )
+            plot_widget.bind('<Button-3>', context_menu.popup)
             plot_widget.pack(fill=X, expand=True)
 
 
 class SeriesContextMenu(tk.Menu):
     def __init__(self, parent, on_aggregate=None, on_describe=None,
                  on_query=None, on_save_figure=None, on_draw=None,
-                 on_delete=None, tear_off=0, **kwargs):
+                 on_delete=None, tearoff=0, **kwargs):
         super().__init__(parent, tearoff=tearoff, **kwargs)
         intervals = ('1ms', '5ms', '50ms', '500ms', '1S', '1min', '30min', '1H',
                      '3H', '6H', 'D', 'W')
         agg_menu = tk.Menu(self)
         for interval in intervals:
+            # Must set interval=interval at lambda definition time to overcome
+            # issue of value of interval being captured at runtime (all the
+            # same final value 'W')
             agg_menu.add_command(
                 label=interval,
-                command=lambda : on_aggregate(interval)
+                command=lambda interval=interval: on_aggregate(interval)
             )
         self.add_cascade(
             label='Aggregate',
@@ -240,11 +253,11 @@ class SeriesContextMenu(tk.Menu):
             command=on_delete
         )
 
-    def popup(event):
+    def popup(self, event):
         try:
             self.tk_popup(event.x_root, event.y_root)
         finally:
-            self.grav_release()
+            self.grab_release()
 
 
 

--- a/src/displayapp.py
+++ b/src/displayapp.py
@@ -147,11 +147,13 @@ class DisplayApp(tk.Tk):
         ]
 
     def update_describe_window(self):
+        print('DisplayApp.update_describe_window()')
         if self.describe_window is None:
             return
         self.describe_window.update(self._active_data, self.interval)
 
     def open_describe_window(self, series):
+        print('DisplayApp.open_describe_window()')
         if self.describe_window:
             self.describe_window.destroy()
         self.describe_window = DescribeWindow(series)


### PR DESCRIPTION
- Added SeriesContextMenu class: a context menu that is instantiated for each series plot  shown on DisplayApp and bound to a right-click on said plot.
- Added creation of SeriesContextMenu for each series plot in DisplayApp (most callbacks are just placeholders, but the on_describe callback is actually implemented. It opens a DescribeWindow for whichever series' context menu)
- Modified DescribeWindow class a bit. It now receives a series name as it's only initializer argument. Also fixed a reference to an old variable name.